### PR TITLE
[FIX] add_header Content-Security-Policy

### DIFF
--- a/srcs/requirements/nginx/conf/nginx.conf
+++ b/srcs/requirements/nginx/conf/nginx.conf
@@ -59,7 +59,11 @@ http {
 		add_header X-XSS-Protection "1; mode=block" always; # to prevent XSS attacks
 		add_header X-Content-Type-Options "nosniff" always; # to prevent MIME type sniffing
 		add_header Referrer-Policy "no-referrer-when-downgrade" always; # to prevent the browser to send the referrer header to the website
-		add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';" always;
+		add_header Content-Security-Policy "default-src 'self'; 
+  			script-src 'self' 'unsafe-eval'; 
+  			style-src 'self'; 
+  			img-src 'self' data: https://upload.wikimedia.org; 
+  			connect-src 'self' wss://localhost;" always;
 		# add_header Content-Security-Policy "default-src 'self';" always; # to prevent the browser to load resources from other domains
 		# add_header Strict-Transport-Security "max-age=31536000; includeSubDomains"; # to force the browser to use HTTPS
 


### PR DESCRIPTION
Modify add_header Content-Security-Policy to allow img from Wiki, encoded in base64, allow eval() and websocket on localhost